### PR TITLE
Updating readme to make the test commands directly copyable

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ The `wallet-service-mirror` crate consists of two standalone executables, that w
 
 The mirror consists of two sides:
    1) A private side. The private side of the mirror runs alongside `full-service` and forms outgoing connections to both `full-service` and to the public side of the mirror. It then proceeds to poll the public side for any requests that should be forwarded to `full-service`, forwards them, and at the next poll opportunity returns any replies. Note how the private side only forms outgoing connections and does not open any listening ports.
+   
    Please Note:
-   The set of available requests is defined in the variable `SUPPORTED_ENDPOINTS`, in the [private main file](src/private/main.rs). It is likely you will want to change the 'SUPPORTED_ENDPOINTS' to include desired features like sending transactions.
+   The set of available requests is defined in the variable `SUPPORTED_ENDPOINTS`, in the [private main file](src/private/main.rs). It is likely you will want to change the `SUPPORTED_ENDPOINTS` to include desired features like sending transactions.
+   
    2) A public side. The public side of the mirror accepts incoming HTTP connections from clients, and poll requests from the private side over GRPC. The client requests are then forwarded over the GRPC channel to the private side, which in turn forwards them to `full-service` and returns the responses.
 
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Once started, the private side should no longer show errors and the mirror shoul
 Query block details:
 
 ```
-curl -s localhost:9091/unsigned-request \
+curl -s "localhost:9091/unsigned-request" \
   -d '{
         "method": "get_block",
         "params": {

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Once started, the private side should no longer show errors and the mirror shoul
 Query block details:
 
 ```
-curl -s "localhost:9091/unsigned-request" \
+curl -s localhost:9091/unsigned-request \
   -d '{
         "method": "get_block",
         "params": {

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 The `wallet-service-mirror` crate consists of two standalone executables, that when used together allow for exposing limited, read-only data from a `full-service` wallet service instance. As explained below, this allows exposing some data from `full-service` from a machine that does not require any incoming connections from the outside world.
 
 The mirror consists of two sides:
-   1) A private side. The private side of the mirror runs alongside `full-service` and forms outgoing connections to both `full-service` and to the public side of the mirror. It then proceeds to poll the public side for any requests that should be forwarded to `full-service`, forwards them, and at the next poll opportunity returns any replies. The set of available requests is defined in the variable `SUPPORTED_ENDPOINTS`, in the [private main file](src/private/main.rs).
-   Note how the private side only forms outgoing connections and does not open any listening ports.
+   1) A private side. The private side of the mirror runs alongside `full-service` and forms outgoing connections to both `full-service` and to the public side of the mirror. It then proceeds to poll the public side for any requests that should be forwarded to `full-service`, forwards them, and at the next poll opportunity returns any replies. Note how the private side only forms outgoing connections and does not open any listening ports.
+   Please Note:
+   The set of available requests is defined in the variable `SUPPORTED_ENDPOINTS`, in the [private main file](src/private/main.rs). It is likely you will want to change the 'SUPPORTED_ENDPOINTS' to include desired features like sending transactions.
    2) A public side. The public side of the mirror accepts incoming HTTP connections from clients, and poll requests from the private side over GRPC. The client requests are then forwarded over the GRPC channel to the private side, which in turn forwards them to `full-service` and returns the responses.
 
 

--- a/create-release/package-mainnet/README.md
+++ b/create-release/package-mainnet/README.md
@@ -10,8 +10,11 @@ Once launched, you can test it using curl:
 
 Get block information (for block 0):
 ```
-$ curl -X POST -H 'Content-Type: application/json' -d '{"method": "get_block", "params": {"block_index": "0"}, "jsonrpc": "2.0", "id": 1}' http://localhost:9091/unsigned-request
-{"method":"get_block","result":{"block":{"id":"dba9b5bb61dc3941c6730a4c5e9b81f30f9def32abd4251d0715100072a7425e","version":"0","parent_id":"0000000000000000000000000000000000000000000000000000000000000000","index":"0","cumulative_txo_count":"16","root_element":{"range":{"from":"0","to":"0"},"hash":"0000000000000000000000000000000000000000000000000000000000000000"},"contents_hash":"882cea8bf5e082294ae1707ad2841c6f4846ece978d077f15bc090ac97885e81"},"block_contents":{"key_images":[],"outputs":[{"amount":{"commitment":"3a72e2231c1462354dfe6d4c289d05c67a528dfcdba52d8d87c07914c507dc5f","masked_value":"28067792405079518"},"target_key":"8c43d0e80adcf7c8a59f6350d010f7b257f2d6454efa7ca693eb92180a06ee6c","public_key":"50c5916be94c0dcba5054fe2852422ec7c5e208cb31355b8e74e8c4ed007a60b","e_fog_hint":"05e32fee11b4612c9fd54f97e9662c8e576ab91d062c62295974cdd940d0a257eb8ce687e9bbbf8e6dccb0ec16bf15ad6902f9c249d2fe1ed198918ec1c614a48b299c657aa32b9e5c3580f24c07e354b31e0100"},{"amou...
+curl -X POST -H 'Content-Type: application/json' -d '{"method": "get_block", "params": {"block_index": "0"}, "jsonrpc": "2.0", "id": 1}' http://localhost:9091/unsigned-request
+```
+
+This should return:
+```{"method":"get_block","result":{"block":{"id":"dba9b5bb61dc3941c6730a4c5e9b81f30f9def32abd4251d0715100072a7425e","version":"0","parent_id":"0000000000000000000000000000000000000000000000000000000000000000","index":"0","cumulative_txo_count":"16","root_element":{"range":{"from":"0","to":"0"},"hash":"0000000000000000000000000000000000000000000000000000000000000000"},"contents_hash":"882cea8bf5e082294ae1707ad2841c6f4846ece978d077f15bc090ac97885e81"},"block_contents":{"key_images":[],"outputs":[{"amount":{"commitment":"3a72e2231c1462354dfe6d4c289d05c67a528dfcdba52d8d87c07914c507dc5f","masked_value":"28067792405079518"},"target_key":"8c43d0e80adcf7c8a59f6350d010f7b257f2d6454efa7ca693eb92180a06ee6c","public_key":"50c5916be94c0dcba5054fe2852422ec7c5e208cb31355b8e74e8c4ed007a60b","e_fog_hint":"05e32fee11b4612c9fd54f97e9662c8e576ab91d062c62295974cdd940d0a257eb8ce687e9bbbf8e6dccb0ec16bf15ad6902f9c249d2fe1ed198918ec1c614a48b299c657aa32b9e5c3580f24c07e354b31e0100"},{"amou...
 ```
 
 For other requests please see https://github.com/mobilecoinofficial/full-service/blob/main/API.md

--- a/create-release/package-mainnet/README.md
+++ b/create-release/package-mainnet/README.md
@@ -17,7 +17,7 @@ This should return:
 ```{"method":"get_block","result":{"block":{"id":"dba9b5bb61dc3941c6730a4c5e9b81f30f9def32abd4251d0715100072a7425e","version":"0","parent_id":"0000000000000000000000000000000000000000000000000000000000000000","index":"0","cumulative_txo_count":"16","root_element":{"range":{"from":"0","to":"0"},"hash":"0000000000000000000000000000000000000000000000000000000000000000"},"contents_hash":"882cea8bf5e082294ae1707ad2841c6f4846ece978d077f15bc090ac97885e81"},"block_contents":{"key_images":[],"outputs":[{"amount":{"commitment":"3a72e2231c1462354dfe6d4c289d05c67a528dfcdba52d8d87c07914c507dc5f","masked_value":"28067792405079518"},"target_key":"8c43d0e80adcf7c8a59f6350d010f7b257f2d6454efa7ca693eb92180a06ee6c","public_key":"50c5916be94c0dcba5054fe2852422ec7c5e208cb31355b8e74e8c4ed007a60b","e_fog_hint":"05e32fee11b4612c9fd54f97e9662c8e576ab91d062c62295974cdd940d0a257eb8ce687e9bbbf8e6dccb0ec16bf15ad6902f9c249d2fe1ed198918ec1c614a48b299c657aa32b9e5c3580f24c07e354b31e0100"},{"amou...
 ```
 
-For other requests please see https://github.com/mobilecoinofficial/full-service/blob/main/API.md
+For other requests please see https://mobilecoin.gitbook.io/full-service-api/
 
 If you want to have a TLS connection between the mirror sides, use `wallet-service-mirror-public-tls.sh` and `wallet-service-mirror-private-tls.sh`. Note that they use a self-signed test certificate stored inside `mirror.crt` / `mirror.key` that was generated with `openssl req -x509 -sha256 -nodes -newkey rsa:2048 -days 365 -keyout mirror.key -out mirror.crt`.
 

--- a/create-release/package-testnet/README.md
+++ b/create-release/package-testnet/README.md
@@ -17,7 +17,7 @@ This returns:
 {"method":"get_block","result":{"block":{"id":"dba9b5bb61dc3941c6730a4c5e9b81f30f9def32abd4251d0715100072a7425e","version":"0","parent_id":"0000000000000000000000000000000000000000000000000000000000000000","index":"0","cumulative_txo_count":"16","root_element":{"range":{"from":"0","to":"0"},"hash":"0000000000000000000000000000000000000000000000000000000000000000"},"contents_hash":"882cea8bf5e082294ae1707ad2841c6f4846ece978d077f15bc090ac97885e81"},"block_contents":{"key_images":[],"outputs":[{"amount":{"commitment":"3a72e2231c1462354dfe6d4c289d05c67a528dfcdba52d8d87c07914c507dc5f","masked_value":"28067792405079518"},"target_key":"8c43d0e80adcf7c8a59f6350d010f7b257f2d6454efa7ca693eb92180a06ee6c","public_key":"50c5916be94c0dcba5054fe2852422ec7c5e208cb31355b8e74e8c4ed007a60b","e_fog_hint":"05e32fee11b4612c9fd54f97e9662c8e576ab91d062c62295974cdd940d0a257eb8ce687e9bbbf8e6dccb0ec16bf15ad6902f9c249d2fe1ed198918ec1c614a48b299c657aa32b9e5c3580f24c07e354b31e0100"},{"amou...
 ```
 
-For other requests please see https://github.com/mobilecoinofficial/full-service/blob/main/API.md
+For other requests please see https://mobilecoin.gitbook.io/full-service-api/
 
 If you want to have a TLS connection between the mirror sides, use `wallet-service-mirror-public-tls.sh` and `wallet-service-mirror-private-tls.sh`. Note that they use a self-signed test certificate stored inside `mirror.crt` / `mirror.key` that was generated with `openssl req -x509 -sha256 -nodes -newkey rsa:2048 -days 365 -keyout mirror.key -out mirror.crt`.
 

--- a/create-release/package-testnet/README.md
+++ b/create-release/package-testnet/README.md
@@ -10,7 +10,10 @@ Once launched, you can test it using curl:
 
 Get block information (for block 0):
 ```
-$ curl -X POST -H 'Content-Type: application/json' -d '{"method": "get_block", "params": {"block_index": "0"}, "jsonrpc": "2.0", "id": 1}' http://localhost:9091/unsigned-request
+curl -X POST -H 'Content-Type: application/json' -d '{"method": "get_block", "params": {"block_index": "0"}, "jsonrpc": "2.0", "id": 1}' http://localhost:9091/unsigned-request
+```
+This returns:
+```
 {"method":"get_block","result":{"block":{"id":"dba9b5bb61dc3941c6730a4c5e9b81f30f9def32abd4251d0715100072a7425e","version":"0","parent_id":"0000000000000000000000000000000000000000000000000000000000000000","index":"0","cumulative_txo_count":"16","root_element":{"range":{"from":"0","to":"0"},"hash":"0000000000000000000000000000000000000000000000000000000000000000"},"contents_hash":"882cea8bf5e082294ae1707ad2841c6f4846ece978d077f15bc090ac97885e81"},"block_contents":{"key_images":[],"outputs":[{"amount":{"commitment":"3a72e2231c1462354dfe6d4c289d05c67a528dfcdba52d8d87c07914c507dc5f","masked_value":"28067792405079518"},"target_key":"8c43d0e80adcf7c8a59f6350d010f7b257f2d6454efa7ca693eb92180a06ee6c","public_key":"50c5916be94c0dcba5054fe2852422ec7c5e208cb31355b8e74e8c4ed007a60b","e_fog_hint":"05e32fee11b4612c9fd54f97e9662c8e576ab91d062c62295974cdd940d0a257eb8ce687e9bbbf8e6dccb0ec16bf15ad6902f9c249d2fe1ed198918ec1c614a48b299c657aa32b9e5c3580f24c07e354b31e0100"},{"amou...
 ```
 


### PR DESCRIPTION
Separating the test commands from the output makes the command easier to run.
Adding a quotes around test command to resolve an error with invalid numerical literal.