### PR TITLE
Use unbounded message length

### DIFF
--- a/src/private/main.rs
+++ b/src/private/main.rs
@@ -107,8 +107,8 @@ fn main() {
     let mirror_api_client = {
         let env = Arc::new(grpcio::EnvBuilder::new().build());
         let ch = ChannelBuilder::new(env)
-            .max_receive_message_len(std::i32::MAX)
-            .max_send_message_len(std::i32::MAX)
+            .max_receive_message_len(-1)
+            .max_send_message_len(-1)
             .max_reconnect_backoff(Duration::from_millis(2000))
             .initial_reconnect_backoff(Duration::from_millis(1000))
             .connect_to_uri(&config.mirror_public_uri, &logger);


### PR DESCRIPTION
Setting the message length to `std::i32::MAX` was resulting in the error on the private mirror when asking for large amounts of information (`get_transaction_logs_for_account`): 

```rpcFailure(RpcStatus { code: 8-RESOURCE_EXHAUSTED, message: "Received message larger than max (17404958 vs. 4194304)```

Moving to `max_receive_message_len` and `max_send_message_len` both = `-1` (no limit) resolves the issue.