### PR TITLE
Add Github action workflow for build and release

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,46 @@
+# Full-Service-Mirror Build Release Process
+
+This Github Action Workflow provides an automated build release process for the full-service-mirror and associated binaries. There are currently two workflows provided.
+
+- ### _tag.yaml_ - Creates a new TAG depending on which branch your code is pushed to.
+
+  - `release/v*` branch will create a new prerelease tag in the format `vx.x.x-pre.x` e.g - v1.5.1-pre.1
+  - `main` branch will create a full release tag in the format `vx.x.x` e.g. - `v1.5.1`
+
+  <br/>
+
+  > **NOTE: By default the tag is bumped at the patch level so if the current release is at `v1.5.0` then a new tag will be created as `v1.5.1-pre.1` when a release/\* branch is pushed. If this release branch is then merged into the main branch a new release tag will be created as `v1.5.1`**
+
+  > The bump level can be overridden by supplying the following on the commit message **#major, #minor, #none**
+
+- ### _build.yaml_ - Builds and uploads artifacts and release binaries. Also builds and pushes docker files to docker hub
+  - Runs when code is pushed to the following branches or any tag:
+    - develop
+    - feature/\*
+    - hotfix/\*
+
+## Push code to repo for any of the following branches
+
+- `develop`
+- `feature/*`
+- `hotfix/*`
+
+1. Code is built
+1. Artifact is created and uploaded to workflow output
+
+## Push code to repo for the following branches
+
+- `release/*`
+- `main`
+
+1. Tag workflow is run creating a new tag for the release.
+1. Build workflow is run because of the `tag` push
+1. Code is built
+1. Artifact is created and uploaded to the workflow output
+1. `Release branch`
+   1. A new prerelease is created
+   1. The artifacts are uploaded to the github releases for the current tag
+1. `Main branch`
+   1. Latest prerelase artifact is downloaded (Promoting the tested binaries)
+   1. A new release is created
+   1. Artifact is uploaded as an official release

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,9 @@
-name: full-service-mirror-build-release
+name: fsm-build
 
 env:
   DOCKERHUB_REPO: mobilecoin/full-service-mirror
+  # CHART_RELEASE_NAME: full-service-mirror
+  # CHART_PATH: ./chart
   SGX_MODE: HW
   IAS_MODE: PROD
   RUST_BACKTRACE: full
@@ -11,10 +13,9 @@ env:
 on:
   push:
     branches:
-      - 'main'
       - 'develop'
-      - 'release/*'
       - 'feature/*'
+      - 'hotfix/*'
     tags:
       - 'v*'
 
@@ -40,7 +41,7 @@ jobs:
         with:
           submodules: recursive
 
-      # CACHE_VERSION is 'date --iso-8601=minutes' and is used to invalidate cache if needed
+      # CACHE_VERSION secret is 'date --iso-8601=minutes' and is used to invalidate cache if needed
       - name: Cache Build Binaries
         id: artifact_cache
         uses: actions/cache@v2
@@ -84,33 +85,26 @@ jobs:
       - name: Copy binaries to cache folder
         if: steps.artifact_cache.outputs.cache-hit != 'true'
         run: |
-          mkdir -p build_artifacts/${{ matrix.network }}/bin
+          mkdir -pv build_artifacts/${{ matrix.network }}/bin
           cp /var/tmp/*.css build_artifacts/${{ matrix.network }}
           cp -R create-release/package-${{ matrix.network }}/* build_artifacts/${{ matrix.network }}
           cp full-service/target/release/full-service build_artifacts/${{ matrix.network }}/bin/
           cp full-service/target/release/mc-validator-service build_artifacts/${{ matrix.network }}/bin/
           cp target/release/wallet-service-mirror-private build_artifacts/${{ matrix.network }}/bin/
           cp target/release/wallet-service-mirror-public build_artifacts/${{ matrix.network }}/bin/
+          cp target/release/generate-rsa-keypair build_artifacts/${{ matrix.network }}/bin/
 
       # Create and Upload an Artifact on Push and Not a Tag
       - name: Create Artifact
-        if: startsWith(github.ref, 'refs/heads/')
         run: |
-          mkdir -p artifact
+          mkdir -pv artifact
           cd artifact && tar -czvf ${{ github.sha }}-${{ matrix.network }}.tar.gz -C ../build_artifacts/${{ matrix.network }}/ .
 
       - name: Upload Artifact
-        if: startsWith(github.ref, 'refs/heads/')
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: full-service-mirror_${{ matrix.network }}
           path: artifact/${{ github.sha }}-${{ matrix.network }}.tar.gz
-
-      - name: Create Release
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: |
-          mkdir -p release
-          cd release && tar -czvf ${{ github.ref_name }}-${{ matrix.network }}.tar.gz -C ../build_artifacts/${{ matrix.network }}/ .
 
       # Does the tag have the "pre" key word in it? Will mark it as prerelease
       - name: Is Prerelease
@@ -119,17 +113,60 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
           if [[ "${GITHUB_REF}" =~ pre ]]; then
-            echo ::set-output name=value::true
+            echo "::set-output name=value::true"
           else
-            echo ::set-output name=value::false
+            echo "::set-output name=value::false"
           fi
+
+      # Only for Tag on Main
+      - name: Get Current Pre-Release
+        if: startsWith(github.ref, 'refs/tags/v') && steps.prerelease.outputs.value == 'false'
+        id: current_release
+        uses: joutvhu/get-release@v1
+        with:
+          debug: true
+          latest: true
+          prerelease: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Only for Tag on Main
+      - name: Download Latest Pre-Release
+        if: startsWith(github.ref, 'refs/tags/v') && steps.prerelease.outputs.value == 'false'
+        uses: duhow/download-github-release-assets@v1
+        with:
+          tag: ${{ steps.current_release.outputs.tag_name }}
+          files: |
+            ${{ steps.current_release.outputs.tag_name }}-${{ matrix.network }}.tar.gz
+          target: /var/tmp/${{ steps.current_release.outputs.tag_name }}-${{ matrix.network }}.tar.gz
+
+      # Only for Tag on Main
+      - name: Extract Release
+        if: startsWith(github.ref, 'refs/tags/v') && steps.prerelease.outputs.value == 'false'
+        run: |
+          rm -rfv build_artifacts/${{ matrix.network }}
+          mkdir -pv build_artifacts/${{ matrix.network }}
+          tar xzvf /var/tmp/${{ steps.current_release.outputs.tag_name }}-${{ matrix.network }}.tar.gz -C build_artifacts/${{ matrix.network }}
+
+      - name: Create Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          mkdir -pv release
+          cd release && tar -czvf ${{ github.ref_name }}-${{ matrix.network }}.tar.gz -C ../build_artifacts/${{ matrix.network }}/ .
+
+      - name: Generate MD5
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          cd release && md5sum ${{ github.ref_name }}-${{ matrix.network }}.tar.gz > ${{ github.ref_name }}-${{ matrix.network }}.md5
 
       - name: Upload Release
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v1
         with:
           prerelease: ${{ steps.prerelease.outputs.value }}
-          files: release/${{ github.ref_name }}-${{ matrix.network }}.tar.gz
+          files: |
+            release/${{ github.ref_name }}-${{ matrix.network }}.tar.gz
+            release/${{ github.ref_name }}-${{ matrix.network }}.md5
 
   docker:
     if: startsWith(github.ref, 'refs/tags/v')
@@ -142,8 +179,6 @@ jobs:
             network: testnet
           - namespace: prod
             network: mainnet
-    outputs:
-      tags: ${{ steps.meta.outputs.tags }}
 
     steps:
       - name: Checkout with submodules
@@ -173,7 +208,7 @@ jobs:
       - name: Extract Release
         if: steps.artifact_cache.outputs.cache-hit != 'true'
         run: |
-          mkdir -p build_artifacts/${{ matrix.network }}
+          mkdir -pv build_artifacts/${{ matrix.network }}
           tar xzvf /var/tmp/${{ github.ref_name }}-${{ matrix.network }}.tar.gz -C build_artifacts/${{ matrix.network }}
 
       - name: Generate Docker Tags
@@ -213,28 +248,3 @@ jobs:
           push: true
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
-
-  # Only create a new tag if push to develop(prerelease) or main(release)
-  # Will automatically bump "#patch" by default
-  # Use "#major", "#minor", "#patch". "#none" in commit message to adjust bump.
-  #
-  # Requires mobilecoin-ci user R/W access and ACTIONS_TOKEN
-  tag:
-    needs: build
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: '0'
-      - name: Github Tag Bump
-        uses: anothrNick/github-tag-action@1.36.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
-          RELEASE_BRANCHES: main
-          PRERELEASE_SUFFIX: pre
-          WITH_V: 'true'
-          DEFAULT_BUMP: patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,6 @@ jobs:
     # Needs write permission for publishing release
     permissions:
       contents: write
-    outputs:
-      tag: ${{ steps.tag.outputs.tag }}
     container:
       image: mobilecoin/rust-sgx-base:0.0.3
     strategy:
@@ -57,11 +55,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
+            /opt/cargo/git
+            /opt/cargo/registry/index
+            /opt/cargo/registry/cache
           key: ${{ runner.os }}-${{ matrix.network }}-${{ secrets.CACHE_VERSION }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Consensus SigStruct
@@ -98,29 +94,23 @@ jobs:
 
       # Create and Upload an Artifact on Push and Not a Tag
       - name: Create Artifact
-        if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/heads/')
         run: |
           mkdir -p artifact
           cd artifact && tar -czvf ${{ github.sha }}-${{ matrix.network }}.tar.gz -C ../build_artifacts/${{ matrix.network }}/ .
 
       - name: Upload Artifact
-        if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/heads/')
         uses: actions/upload-artifact@v2
         with:
           name: full-service-mirror_${{ matrix.network }}
           path: artifact/${{ github.sha }}-${{ matrix.network }}.tar.gz
 
-      # Create and Upload a GH Release if it is a tag
-      - name: Get the Tag
-        if: startsWith(github.ref, 'refs/tags/v')
-        id: tag
-        uses: dawidd6/action-get-tag@v1
-
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
           mkdir -p release
-          cd release && tar -czvf ${{ steps.tag.outputs.tag }}-${{ matrix.network }}.tar.gz -C ../build_artifacts/${{ matrix.network }}/ .
+          cd release && tar -czvf ${{ github.ref_name }}-${{ matrix.network }}.tar.gz -C ../build_artifacts/${{ matrix.network }}/ .
 
       # Does the tag have the "pre" key word in it? Will mark it as prerelease
       - name: Is Prerelease
@@ -128,7 +118,7 @@ jobs:
         id: prerelease
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
-          if [[ $GITHUB_REF == *"pre"* ]]; then
+          if [[ "${GITHUB_REF}" =~ pre ]]; then
             echo ::set-output name=value::true
           else
             echo ::set-output name=value::false
@@ -139,7 +129,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           prerelease: ${{ steps.prerelease.outputs.value }}
-          files: release/${{ steps.tag.outputs.tag }}-${{ matrix.network }}.tar.gz
+          files: release/${{ github.ref_name }}-${{ matrix.network }}.tar.gz
 
   docker:
     if: startsWith(github.ref, 'refs/tags/v')
@@ -175,16 +165,16 @@ jobs:
         if: steps.artifact_cache.outputs.cache-hit != 'true'
         uses: duhow/download-github-release-assets@v1
         with:
-          tag: ${{ needs.build.outputs.tag }}
+          tag: ${{ github.ref_name }}
           files: |
-            ${{ needs.build.outputs.tag }}-${{ matrix.network }}.tar.gz
-          target: /var/tmp/${{ needs.build.outputs.tag }}-${{ matrix.network }}.tar.gz
+            ${{ github.ref_name }}-${{ matrix.network }}.tar.gz
+          target: /var/tmp/${{ github.ref_name }}-${{ matrix.network }}.tar.gz
 
       - name: Extract Release
         if: steps.artifact_cache.outputs.cache-hit != 'true'
         run: |
           mkdir -p build_artifacts/${{ matrix.network }}
-          tar xzvf /var/tmp/${{ needs.build.outputs.tag }}-${{ matrix.network }}.tar.gz -C build_artifacts/${{ matrix.network }}
+          tar xzvf /var/tmp/${{ github.ref_name }}-${{ matrix.network }}.tar.gz -C build_artifacts/${{ matrix.network }}
 
       - name: Generate Docker Tags
         id: meta

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,250 @@
+name: full-service-mirror-build-release
+
+env:
+  DOCKERHUB_REPO: mobilecoin/full-service-mirror
+  SGX_MODE: HW
+  IAS_MODE: PROD
+  RUST_BACKTRACE: full
+  CONSENSUS_ENCLAVE_CSS: /var/tmp/consensus-enclave.css
+  INGEST_ENCLAVE_CSS: /var/tmp/ingest-enclave.css
+
+on:
+  push:
+    branches:
+      - 'main'
+      - 'develop'
+      - 'release/*'
+      - 'feature/*'
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    # Needs write permission for publishing release
+    permissions:
+      contents: write
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+    container:
+      image: mobilecoin/rust-sgx-base:0.0.3
+    strategy:
+      matrix:
+        include:
+          - namespace: test
+            network: testnet
+          - namespace: prod
+            network: mainnet
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      # CACHE_VERSION is 'date --iso-8601=minutes' and is used to invalidate cache if needed
+      - name: Cache Build Binaries
+        id: artifact_cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            build_artifacts
+          key: ${{ runner.os }}-${{ matrix.network }}-${{ secrets.CACHE_VERSION }}-build-cargo-artifacts-${{ hashFiles('**/*.rs', '**/*.proto', '**/Cargo.toml')}}
+
+      - name: Cache Cargo
+        if: steps.artifact_cache.outputs.cache-hit != 'true'
+        id: cargo_cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ matrix.network }}-${{ secrets.CACHE_VERSION }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Consensus SigStruct
+        if: steps.artifact_cache.outputs.cache-hit != 'true'
+        run: |
+          CONSENSUS_SIGSTRUCT_URI=$(curl -s https://enclave-distribution.${{ matrix.namespace }}.mobilecoin.com/production.json | grep consensus-enclave.css | awk '{print $2}' | tr -d \" | tr -d ,)
+          (cd /var/tmp && curl -O https://enclave-distribution.${{ matrix.namespace }}.mobilecoin.com/${CONSENSUS_SIGSTRUCT_URI})
+
+      - name: Ingest SigStruct
+        if: steps.artifact_cache.outputs.cache-hit != 'true'
+        run: |
+          INGEST_SIGSTRUCT_URI=$(curl -s https://enclave-distribution.${{ matrix.namespace }}.mobilecoin.com/production.json | grep ingest-enclave.css | awk '{print $2}' | tr -d \" | tr -d ,)
+          (cd /var/tmp && curl -O https://enclave-distribution.${{ matrix.namespace }}.mobilecoin.com/${INGEST_SIGSTRUCT_URI})
+
+      - name: Cargo Build
+        if: steps.artifact_cache.outputs.cache-hit != 'true'
+        run: |
+          cargo build --release \
+          --manifest-path full-service/Cargo.toml \
+          -p mc-full-service \
+          -p mc-validator-service \
+          && cargo build --release
+
+      - name: Copy binaries to cache folder
+        if: steps.artifact_cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p build_artifacts/${{ matrix.network }}/bin
+          cp /var/tmp/*.css build_artifacts/${{ matrix.network }}
+          cp -R create-release/package-${{ matrix.network }}/* build_artifacts/${{ matrix.network }}
+          cp full-service/target/release/full-service build_artifacts/${{ matrix.network }}/bin/
+          cp full-service/target/release/mc-validator-service build_artifacts/${{ matrix.network }}/bin/
+          cp target/release/wallet-service-mirror-private build_artifacts/${{ matrix.network }}/bin/
+          cp target/release/wallet-service-mirror-public build_artifacts/${{ matrix.network }}/bin/
+
+      # Create and Upload an Artifact on Push and Not a Tag
+      - name: Create Artifact
+        if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/v')
+        run: |
+          mkdir -p artifact
+          cd artifact && tar -czvf ${{ github.sha }}-${{ matrix.network }}.tar.gz -C ../build_artifacts/${{ matrix.network }}/ .
+
+      - name: Upload Artifact
+        if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/v')
+        uses: actions/upload-artifact@v2
+        with:
+          name: full-service-mirror_${{ matrix.network }}
+          path: artifact/${{ github.sha }}-${{ matrix.network }}.tar.gz
+
+      # Create and Upload a GH Release if it is a tag
+      - name: Get the Tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        id: tag
+        uses: dawidd6/action-get-tag@v1
+
+      - name: Create Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          mkdir -p release
+          cd release && tar -czvf ${{ steps.tag.outputs.tag }}-${{ matrix.network }}.tar.gz -C ../build_artifacts/${{ matrix.network }}/ .
+
+      # Does the tag have the "pre" key word in it? Will mark it as prerelease
+      - name: Is Prerelease
+        shell: bash
+        id: prerelease
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          if [[ $GITHUB_REF == *"pre"* ]]; then
+            echo ::set-output name=value::true
+          else
+            echo ::set-output name=value::false
+          fi
+
+      - name: Upload Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v1
+        with:
+          prerelease: ${{ steps.prerelease.outputs.value }}
+          files: release/${{ steps.tag.outputs.tag }}-${{ matrix.network }}.tar.gz
+
+  docker:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      matrix:
+        include:
+          - namespace: test
+            network: testnet
+          - namespace: prod
+            network: mainnet
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
+
+    steps:
+      - name: Checkout with submodules
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Cache Build Binaries
+        id: artifact_cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            build_artifacts
+          key: ${{ runner.os }}-${{ matrix.network }}-${{ secrets.CACHE_VERSION }}-build-cargo-artifacts-${{ hashFiles('**/*.rs', '**/*.proto', '**/Cargo.toml')}}
+
+      # Caching seems to not work when you push a tag (I think because of scope) so download the just uploaded release
+      # See issue here: https://github.com/actions/cache/issues/556
+      - name: Download Release on Cache Miss
+        if: steps.artifact_cache.outputs.cache-hit != 'true'
+        uses: duhow/download-github-release-assets@v1
+        with:
+          tag: ${{ needs.build.outputs.tag }}
+          files: |
+            ${{ needs.build.outputs.tag }}-${{ matrix.network }}.tar.gz
+          target: /var/tmp/${{ needs.build.outputs.tag }}-${{ matrix.network }}.tar.gz
+
+      - name: Extract Release
+        if: steps.artifact_cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p build_artifacts/${{ matrix.network }}
+          tar xzvf /var/tmp/${{ needs.build.outputs.tag }}-${{ matrix.network }}.tar.gz -C build_artifacts/${{ matrix.network }}
+
+      - name: Generate Docker Tags
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.DOCKERHUB_REPO }}
+          flavor: |
+            latest=false
+            suffix=-${{ matrix.network }}
+          tags: |
+            type=semver,pattern=v{{version}},priority=20
+            type=sha,priority=10
+
+      - name: Setup Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          install: true
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Publish to DockerHub
+        id: docker_publish_dockerhub
+        uses: docker/build-push-action@v2
+        with:
+          build-args: |
+            NETWORK=${{ matrix.network }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          context: .
+          file: Dockerfile.ci
+          push: true
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+
+  # Only create a new tag if push to develop(prerelease) or main(release)
+  # Will automatically bump "#patch" by default
+  # Use "#major", "#minor", "#patch". "#none" in commit message to adjust bump.
+  #
+  # Requires mobilecoin-ci user R/W access and ACTIONS_TOKEN
+  tag:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+      - name: Github Tag Bump
+        uses: anothrNick/github-tag-action@1.36.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+          RELEASE_BRANCHES: main
+          PRERELEASE_SUFFIX: pre
+          WITH_V: 'true'
+          DEFAULT_BUMP: patch

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -1,0 +1,31 @@
+name: fsm-tag
+
+on:
+  push:
+    branches:
+      - 'main'
+      - 'release/*'
+
+jobs:
+  # Only create a new tag if push to develop(prerelease) or main(release)
+  # Will automatically bump "#patch" by default
+  # Use "#major", "#minor", "#patch". "#none" in commit message to adjust bump.
+  #
+  # Requires mobilecoin-ci user R/W access and ACTIONS_TOKEN
+  tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+      - name: Github Tag Bump
+        uses: anothrNick/github-tag-action@1.36.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+          RELEASE_BRANCHES: main
+          PRERELEASE_SUFFIX: pre
+          WITH_V: 'true'
+          DEFAULT_BUMP: patch

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,0 +1,52 @@
+# syntax=docker/dockerfile:1.2
+
+# Runtime image for the wallet service mirror (public/private) nodes.
+# Binaries included:
+#   full-service, mc-validator-service, full-service-mirror-public, full-service-mirror-private 
+
+# This build requires BuildKit and is used from within Github Actions
+
+FROM ubuntu:focal-20211006
+
+# Need to pass in testnet/mainnet to grab the build artifacts
+ARG NETWORK
+
+RUN addgroup --system --gid 1000 app \
+  && adduser --system --ingroup app --uid 1000 app \
+  && mkdir /data \
+  && chown app:app /data
+
+RUN apt-get update \
+  && apt-get upgrade -y \
+  && apt-get install -y ca-certificates \
+  && apt-get clean \
+  && rm -r /var/lib/apt/lists \
+  && mkdir -p /usr/share/grpc \
+  && ln -s /etc/ssl/certs/ca-certificates.crt /usr/share/grpc/roots.pem
+
+COPY build_artifacts/${NETWORK}/*.css /usr/local/bin/
+COPY build_artifacts/${NETWORK}/bin/full-service /usr/local/bin/full-service
+COPY build_artifacts/${NETWORK}/bin/mc-validator-service /usr/local/bin/mc-validator-service
+COPY build_artifacts/${NETWORK}/bin/wallet-service-mirror-private /usr/local/bin/wallet-service-mirror-private
+COPY build_artifacts/${NETWORK}/bin/wallet-service-mirror-public /usr/local/bin/wallet-service-mirror-public
+
+USER app
+VOLUME /data
+
+ENV RUST_BACKTRACE="1"
+ENV RUST_LOG=info,rustls=warn,hyper=warn,tokio_reactor=warn,mio=warn,want=warn,rusoto_core=error,h2=error,reqwest=error,rocket=error,<unknown>=error
+ENV RUST_LOG_STYLE="never"
+ENV INGEST_ENCLAVE_CSS=/usr/local/bin/ingest-enclave.css
+ENV CONSENSUS_ENCLAVE_CSS=/usr/local/bin/consensus-enclave.css
+
+# Default ports
+# full-service grpc
+EXPOSE 9090
+# mc-validator-service grpc
+EXPOSE 5554
+# full-service-mirror-public grpc
+EXPOSE 10080
+# full-service-mirror-public http(s) client
+EXPOSE 9091
+
+CMD [ "bash"]


### PR DESCRIPTION
Soundtrack of this PR: [Night Flow](https://www.youtube.com/watch?v=K8kXcNqWN8g)

## Motivation
This PR adds full Build and Release of the Ledger Validator System by automating the code builds for the binaries that make up the Ledger Validator Service.  This GitHub Action workflow will automatically bump the tags and produce both pre-releases and final releases.  Downloadable artifacts are created and saved to the Action output. The workflow will also create Docker Images for pushed tags and publish them to Docker Hub.

## Included In this PR:
- Monitors for `push` events to the following branches and tags
  - main
  - develop
  - release/*
  - feature/*
  - hotfix/*
  - v* (tags)

- Builds the binaries
  - full-service
  - mc-validator-service
  - wallet-service-mirror-private
  - wallet-service-mirror-public
  - generate-rsa-keypair

- Push to any of the above branches _except_ `main` or `release/*`
  - Code is built and if successful an artifact is created and uploaded to the GitHub action output.
        
- Push to `release/*` or `main` branch
  - _tag_ workflow is kicked off to create a new tag. Either a prerelease `vx.x.x-pre.x` or just `v.x.x.x`
  - Push of a new tag will kick off the _build_ workflow to build the code and upload the (pre)release. 
    - Code is built and artifacts and docker images uploaded
  - Docker images are pushed to the Docker Hub repo `mobilecoin/full-service-mirror`


> **You can supply one of the following commands in the commit message to adjust what gets bumped in the semver.**
> "#major", "#minor", "#patch". "#none"

![image](https://user-images.githubusercontent.com/3493649/159382572-787a532c-9295-4e89-8361-a92064e2587b.png)


## Future Work
- Update Helm chart to add the `mc-validator-service`
- Wire up the deploy steps so when code is pushed to develop or main that version gets auto deployed to the kubernetes clusters for testing/validation



