### PR TITLE
Use raw octet-stream for encrypted requests

### DIFF
--- a/create-release/package-mainnet/example-client.js
+++ b/create-release/package-mainnet/example-client.js
@@ -12,7 +12,7 @@ const crypto = require('crypto');
 // Command line parsing
 if (process.argv.length != 6) {
     console.log(`Usage: node example-client.js <public mirror host> <public mirror port> <key file> <request>`);
-    console.log(`For example: node example-client.js 127.0.0.1 9091 mirror-client.pem '{"GetBlock": {"block": 0}}'`);
+    console.log(`For example: node example-client.js 127.0.0.1 9091 mirror-client.pem '{"method": "get_block", "params": {"block_index": "0"}, "jsonrpc": "2.0", "id": 1}'`);
     console.log('To generate keys please run the generate-rsa-keypair binary. See README.md for more details')
     return;
 }
@@ -42,9 +42,7 @@ if (test_data.length != KEY_SIZE) {
 
 // Prepare request
 let encrypted_request = encrypt(request);
-let post_data = JSON.stringify({
-    payload: [...encrypted_request],
-});
+
 // Send request to server
 let req = http.request({
     host: public_mirror_host,
@@ -53,8 +51,8 @@ let req = http.request({
     path: '/encrypted-request',
     method: 'POST',
     headers: {
-        'Content-Type': 'application/json',
-        'Content-Length': Buffer.byteLength(post_data)
+        'Content-Type': 'application/octet-stream',
+        'Content-Length': Buffer.byteLength(encrypted_request)
     }
 }, (response) => {
     let buf = []
@@ -76,7 +74,7 @@ let req = http.request({
     })
 }
 )
-req.write(post_data)
+req.write(encrypted_request)
 req.end()
 
 // Crypto utilities
@@ -117,5 +115,5 @@ function decrypt(buf) {
 }
 
 function sign(buf) {
-    return crypto.sign(null, Buffer.from(buf), { key, passphrase: '' })
+    return crypto.sign(null, Buffer.from(buf), {key, passphrase: ''})
 }

--- a/create-release/package-testnet/example-client.js
+++ b/create-release/package-testnet/example-client.js
@@ -12,7 +12,7 @@ const crypto = require('crypto');
 // Command line parsing
 if (process.argv.length != 6) {
     console.log(`Usage: node example-client.js <public mirror host> <public mirror port> <key file> <request>`);
-    console.log(`For example: node example-client.js 127.0.0.1 9091 mirror-client.pem '{"GetBlock": {"block": 0}}'`);
+    console.log(`For example: node example-client.js 127.0.0.1 9091 mirror-client.pem '{"method": "get_block", "params": {"block_index": "0"}, "jsonrpc": "2.0", "id": 1}'`);
     console.log('To generate keys please run the generate-rsa-keypair binary. See README.md for more details')
     return;
 }
@@ -42,9 +42,7 @@ if (test_data.length != KEY_SIZE) {
 
 // Prepare request
 let encrypted_request = encrypt(request);
-let post_data = JSON.stringify({
-    payload: [...encrypted_request],
-});
+
 // Send request to server
 let req = http.request({
     host: public_mirror_host,
@@ -53,8 +51,8 @@ let req = http.request({
     path: '/encrypted-request',
     method: 'POST',
     headers: {
-        'Content-Type': 'application/json',
-        'Content-Length': Buffer.byteLength(post_data)
+        'Content-Type': 'application/octet-stream',
+        'Content-Length': Buffer.byteLength(encrypted_request)
     }
 }, (response) => {
     let buf = []
@@ -76,7 +74,7 @@ let req = http.request({
     })
 }
 )
-req.write(post_data)
+req.write(encrypted_request)
 req.end()
 
 // Crypto utilities
@@ -117,5 +115,5 @@ function decrypt(buf) {
 }
 
 function sign(buf) {
-    return crypto.sign(null, Buffer.from(buf), { key, passphrase: '' })
+    return crypto.sign(null, Buffer.from(buf), {key, passphrase: ''})
 }

--- a/example-client.js
+++ b/example-client.js
@@ -12,7 +12,7 @@ const crypto = require('crypto');
 // Command line parsing
 if (process.argv.length != 6) {
     console.log(`Usage: node example-client.js <public mirror host> <public mirror port> <key file> <request>`);
-    console.log(`For example: node example-client.js 127.0.0.1 9091 mirror-client.pem '{"GetBlock": {"block": 0}}'`);
+    console.log(`For example: node example-client.js 127.0.0.1 9091 mirror-client.pem '{"method": "get_block", "params": {"block_index": "0"}, "jsonrpc": "2.0", "id": 1}'`);
     console.log('To generate keys please run the generate-rsa-keypair binary. See README.md for more details')
     return;
 }
@@ -42,9 +42,7 @@ if (test_data.length != KEY_SIZE) {
 
 // Prepare request
 let encrypted_request = encrypt(request);
-let post_data = JSON.stringify({
-    payload: [...encrypted_request],
-});
+
 // Send request to server
 let req = http.request({
     host: public_mirror_host,
@@ -53,8 +51,8 @@ let req = http.request({
     path: '/encrypted-request',
     method: 'POST',
     headers: {
-        'Content-Type': 'application/json',
-        'Content-Length': Buffer.byteLength(post_data)
+        'Content-Type': 'application/octet-stream',
+        'Content-Length': Buffer.byteLength(encrypted_request)
     }
 }, (response) => {
     let buf = []
@@ -76,7 +74,7 @@ let req = http.request({
     })
 }
 )
-req.write(post_data)
+req.write(encrypted_request)
 req.end()
 
 // Crypto utilities


### PR DESCRIPTION
There's no need to go through JSON when passing raw encrypted data.