### PR TITLE
Add Actions deployment. Update Helm to include validator service

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,8 +2,6 @@ name: fsm-build
 
 env:
   DOCKERHUB_REPO: mobilecoin/full-service-mirror
-  # CHART_RELEASE_NAME: full-service-mirror
-  # CHART_PATH: ./chart
   SGX_MODE: HW
   IAS_MODE: PROD
   RUST_BACKTRACE: full
@@ -21,12 +19,14 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, large]
     # Needs write permission for publishing release
     permissions:
       contents: write
     container:
-      image: mobilecoin/rust-sgx-base:0.0.3
+      image: mobilecoin/rust-sgx-base:0.0.4
+    outputs:
+      prerelease: ${{ steps.prerelease.outputs.value }}
     strategy:
       matrix:
         include:
@@ -172,6 +172,9 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     needs: build
+    outputs:
+      prerelease: ${{ needs.build.outputs.prerelease }}
+      dockerhub_repo: ${{ env.DOCKERHUB_REPO }}
     strategy:
       matrix:
         include:
@@ -220,7 +223,7 @@ jobs:
             latest=false
             suffix=-${{ matrix.network }}
           tags: |
-            type=semver,pattern=v{{version}},priority=20
+            type=semver,pattern={{raw}},priority=20
             type=sha,priority=10
 
       - name: Setup Docker Buildx
@@ -248,3 +251,17 @@ jobs:
           push: true
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
+
+  deploy:
+    needs: [docker]
+    uses: ./.github/workflows/deploy.yaml
+    with:
+      prerelease: ${{ needs.docker.outputs.prerelease }}
+      dockerhub_repo: ${{ needs.docker.outputs.dockerhub_repo }}
+    secrets:
+      RANCHER_URL: ${{ secrets.RANCHER_URL }}
+      RANCHER_TOKEN: ${{ secrets.RANCHER_TOKEN }}
+      STAGING_CLUSTER: ${{ secrets.STAGING_CLUSTER }}
+      PRODUCTION_CLUSTER: ${{ secrets.PRODUCTION_CLUSTER }}
+      TESTNET_VALUES: ${{ secrets.TESTNET_VALUES }}
+      MAINNET_VALUES: ${{ secrets.MAINNET_VALUES }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,93 @@
+name: fsm-deploy
+
+env:
+  CHART_RELEASE_NAME: full-service-mirror
+  CHART_PATH: ./chart
+
+on:
+  workflow_call:
+    inputs:
+      prerelease:
+        required: true
+        type: string
+      dockerhub_repo:
+        required: true
+        type: string
+    secrets:
+      RANCHER_URL:
+        required: true
+      RANCHER_TOKEN:
+        required: true
+      STAGING_CLUSTER:
+        required: true
+      PRODUCTION_CLUSTER:
+        required: true
+      TESTNET_VALUES:
+        required: true
+      MAINNET_VALUES:
+        required: true
+
+jobs:
+  deploy-staging:
+    if: ${{ inputs.prerelease == 'true'}}
+    strategy:
+      matrix:
+        include:
+          - network: testnet
+            namespace: fsm-staging-testnet
+            values: TESTNET_VALUES
+          - network: mainnet
+            namespace: fsm-staging-mainnet
+            values: MAINNET_VALUES
+    runs-on: ubuntu-latest
+    container:
+      image: alpine/helm
+      options: --entrypoint /bin/sh
+    env:
+      RANCHER_URL: ${{ secrets.RANCHER_URL }}
+      RANCHER_TOKEN: ${{ secrets.RANCHER_TOKEN }}
+      RANCHER_CLUSTER: ${{ secrets.STAGING_CLUSTER }}
+      RANCHER_CLUSTER_NAMESPACE: ${{ matrix.namespace }}
+      VALUES: ${{ secrets[matrix.values] }}
+      TAGS: ${{ inputs.dockerhub_repo }}:${{ github.ref_name }}-${{ matrix.network }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Deploy
+        run: |
+          apk add --no-cache bash curl jq
+          .github/workflows/helpers/rancher_deploy.sh
+
+  deploy-production:
+    if: ${{ inputs.prerelease == 'false' }}
+    strategy:
+      matrix:
+        include:
+          - network: testnet
+            namespace: fsm-prod-testnet
+            values: TESTNET_VALUES
+          - network: mainnet
+            namespace: fsm-prod-mainnet
+            values: MAINNET_VALUES
+    runs-on: ubuntu-latest
+    container:
+      image: alpine/helm
+      options: --entrypoint /bin/sh
+    env:
+      RANCHER_URL: ${{ secrets.RANCHER_URL }}
+      RANCHER_TOKEN: ${{ secrets.RANCHER_TOKEN }}
+      RANCHER_CLUSTER: ${{ secrets.PRODUCTION_CLUSTER }}
+      RANCHER_CLUSTER_NAMESPACE: ${{ matrix.namespace }}
+      VALUES: ${{ secrets[matrix.values] }}
+      TAGS: ${{ inputs.dockerhub_repo }}:${{ github.ref_name }}-${{ matrix.network }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Deploy
+        run: |
+          apk add --no-cache bash curl jq
+          .github/workflows/helpers/rancher_deploy.sh

--- a/.github/workflows/helpers/rancher_deploy.sh
+++ b/.github/workflows/helpers/rancher_deploy.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+if [[ -z "${RANCHER_TOKEN}" ]]; then
+  echo "RANCHER_TOKEN required"
+  exit 1
+fi
+
+if [[ -z "${RANCHER_URL}" ]]; then
+  echo "RANCHER_URL required"
+  exit 1
+fi
+
+if [[ -z "${RANCHER_CLUSTER}" ]]; then
+  echo "RANCHER_CLUSTER required"
+  exit 1
+fi
+
+if [[ -z "${RANCHER_CLUSTER_NAMESPACE}" ]]; then
+  echo "RANCHER_CLUSTER_NAMESPACE required"
+  exit 1
+fi
+
+if [[ -z "${CHART_PATH}" ]]; then
+  echo "CHART_PATH required"
+  exit 1
+fi
+
+if [[ -z "${VALUES}" ]]; then
+  echo "VALUES required"
+  exit 1
+fi
+
+if [[ -z "${TAGS}" ]]; then
+  echo "TAGS required"
+  exit 1
+fi
+
+if [[ -z "${CHART_RELEASE_NAME}" ]]; then
+  echo "CHART_RELEASE_NAME required"
+  exit 1
+fi
+
+# Parse Tag - grab the first tag - Format org/repo:tag,org/repo:tag
+TAG=$(echo -n "${TAGS}" | head -1 | awk -F ':' '{print $2}')
+echo "-- Found TAG: ${TAG}"
+
+# replace image tag in values content.
+echo "-- Generate values.yaml content"
+echo "${VALUES}" | sed -e "s/%TAG%/$TAG/g" > ./values.yaml
+
+# Get kubeconfig generation url
+echo "-- Rancher: Get kubeconfig for ${RANCHER_CLUSTER} ${RANCHER_URL}"
+auth_header="Authorization: Bearer ${RANCHER_TOKEN}"
+kubeconfig_url=$(curl -sSLf -H "${auth_header}" "${RANCHER_URL}/v3/clusters/?name=${RANCHER_CLUSTER}" | jq -r .data[0].actions.generateKubeconfig)
+
+# Write kubeconfig to default location
+mkdir -p ~/.kube
+curl -sSLf -H "${auth_header}" -X POST "${kubeconfig_url}" | jq -r .config > ~/.kube/config
+
+# Helm upgrade
+echo "-- Helm: install/upgrade chart ${CHART_PATH}"
+helm upgrade ${CHART_RELEASE_NAME} ${CHART_PATH} --namespace ${RANCHER_CLUSTER_NAMESPACE} --install --atomic -f ./values.yaml

--- a/.github/workflows/helpers/values_template_mainnet.yaml
+++ b/.github/workflows/helpers/values_template_mainnet.yaml
@@ -1,0 +1,18 @@
+mirrorServiceTLS: true
+image:
+  tag: '%TAG%' # Token used in rancher_deploy.sh
+
+ledgerValidator:
+  args:
+    - /usr/local/bin/mc-validator-service
+    - --ledger-db=/data/ledger.db
+    - --peer=mc://node1.prod.mobilecoinww.com/
+    - --peer=mc://node2.prod.mobilecoinww.com/
+    - --tx-source-url=https://ledger.mobilecoinww.com/node1.prod.mobilecoinww.com/
+    - --tx-source-url=https://ledger.mobilecoinww.com/node2.prod.mobilecoinww.com/
+
+fullService:
+  args:
+    - /usr/local/bin/full-service
+    - --wallet-db=/data/wallet.db
+    - --ledger-db=/data/ledger.db

--- a/.github/workflows/helpers/values_template_testnet.yaml
+++ b/.github/workflows/helpers/values_template_testnet.yaml
@@ -1,0 +1,18 @@
+mirrorServiceTLS: true
+image:
+  tag: '%TAG%' # Token used in rancher_deploy.sh
+
+ledgerValidator:
+  args:
+    - /usr/local/bin/mc-validator-service
+    - --ledger-db=/data/ledger.db
+    - --peer=mc://node1.test.mobilecoin.com/
+    - --peer=mc://node2.test.mobilecoin.com/
+    - --tx-source-url=https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node1.test.mobilecoin.com/
+    - --tx-source-url=https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node2.test.mobilecoin.com/
+
+fullService:
+  args:
+    - /usr/local/bin/full-service
+    - --wallet-db=/data/wallet.db
+    - --ledger-db=/data/ledger.db

--- a/chart/templates/full-service-service.yaml
+++ b/chart/templates/full-service-service.yaml
@@ -10,7 +10,7 @@ spec:
   type: ClusterIP
   publishNotReadyAddresses: true
   ports:
-    - port: 9090
+    - port: {{ .Values.fullService.listenPort }}
       targetPort: full-service
       protocol: TCP
       name: full-service

--- a/chart/templates/full-service-statefulset.yaml
+++ b/chart/templates/full-service-statefulset.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "chart.fullname" . }}-full-service
   labels:
     {{- include "chart.labels" . | nindent 4 }}
+    app: full-service
 spec:
   replicas: {{ .Values.fullService.replicaCount }}
   selector:
@@ -35,17 +36,31 @@ spec:
             drop:
             - all
           readOnlyRootFilesystem: true
-        image: "{{ .Values.fullService.image.repository }}:{{ .Values.fullService.image.tag }}"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.fullService.imagePullPolicy }}
         args:
           {{- toYaml .Values.fullService.args | nindent 10 }}
+          - --listen-host=0.0.0.0
+          - --fog-ingest-enclave-css=/usr/local/bin/ingest-enclave.css
+          {{- if eq .Values.ledgerValidator.enabled true }}
+            {{- if eq .Values.mirrorServiceTLS true }}
+          - --validator=validator://{{ include "chart.fullname" . }}-ledger-validator:{{ .Values.ledgerValidator.listenPort }}/?ca-bundle=/certs/ca.crt
+            {{- else }}
+          - --validator=insecure-validator://{{ include "chart.fullname" . }}-ledger-validator:{{ .Values.ledgerValidator.listenPort }}/  
+            {{- end }}
+          {{- end }}
         ports:
         - name: full-service
-          containerPort: 9090
+          containerPort: {{ .Values.fullService.listenPort }}
           protocol: TCP
         volumeMounts:
         - name: data
           mountPath: /data
+        {{- if eq .Values.mirrorServiceTLS true }}
+        - name: tls-cert
+          mountPath: /certs
+          readOnly: true
+        {{- end }}
         resources:
           {{- toYaml .Values.fullService.resources | nindent 12 }}
       nodeSelector:
@@ -54,10 +69,15 @@ spec:
         {{- toYaml .Values.fullService.affinity | nindent 8 }}
       tolerations:
         {{- toYaml .Values.fullService.tolerations | nindent 8 }}
-      {{- if eq .Values.fullService.persistence.enabled false }}
       volumes:
+      {{- if eq .Values.fullService.persistence.enabled false }}
       - name: data
         emptyDir: {}
+      {{- end }}
+      {{- if eq .Values.mirrorServiceTLS true }}
+        - name: tls-cert
+          secret:
+            secretName: {{ include "chart.fullname" .}}-lvn-cert-tls
       {{- end }}
   {{- if .Values.fullService.persistence.enabled }}
   volumeClaimTemplates:

--- a/chart/templates/ledger-validator-certificate.yaml
+++ b/chart/templates/ledger-validator-certificate.yaml
@@ -1,0 +1,14 @@
+{{- if eq .Values.mirrorServiceTLS true }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "chart.fullname" . }}-lvn-cert
+spec:
+  dnsNames:
+    - {{ include "chart.fullname" . }}-ledger-validator
+    - {{ include "chart.fullname" . }}-ledger-validator.{{ .Release.Namespace }}.svc.cluster.local
+  secretName: {{ include "chart.fullname" . }}-lvn-cert-tls
+  issuerRef:
+    name: internal-ca-issuer
+    kind: ClusterIssuer
+{{- end }}

--- a/chart/templates/ledger-validator-service.yaml
+++ b/chart/templates/ledger-validator-service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.ledgerValidator.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "chart.fullname" . }}-ledger-validator
+  labels:
+    app: ledger-validator
+    {{- include "chart.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  ports:
+    - port: {{ .Values.ledgerValidator.listenPort }}
+      targetPort: validator
+      protocol: TCP
+      name: validator
+  selector:
+    {{- include "chart.selectorLabels" . | nindent 4 }}
+    app: ledger-validator
+{{- end }}

--- a/chart/templates/ledger-validator-statefulset.yaml
+++ b/chart/templates/ledger-validator-statefulset.yaml
@@ -1,0 +1,85 @@
+{{- if .Values.ledgerValidator.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "chart.fullname" . }}-ledger-validator
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    app: ledger-validator-node
+spec:
+  replicas: {{ .Values.ledgerValidator.replicaCount }}
+  selector:
+    matchLabels:
+      app: ledger-validator
+      {{- include "chart.selectorLabels" . | nindent 6 }}
+  serviceName: {{ include "chart.fullname" . }}-ledger-validator
+  template:
+    metadata:
+      annotations:
+        {{- toYaml .Values.ledgerValidator.podAnnotations | nindent 8 }}
+      labels:
+        app: ledger-validator
+        {{- include "chart.selectorLabels" . | nindent 8 }}
+    spec:
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      terminationGracePeriodSeconds: 30
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 2000
+        fsGroupChangePolicy: "OnRootMismatch"
+      containers:
+      - name: ledger-validator
+        securityContext:
+          capabilities:
+            drop:
+            - all
+          readOnlyRootFilesystem: true
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.ledgerValidator.imagePullPolicy }}
+        args:
+          {{- toYaml .Values.ledgerValidator.args | nindent 10 }}
+          {{- if eq .Values.mirrorServiceTLS true }}
+          - --listen-uri=validator://0.0.0.0:{{ .Values.ledgerValidator.listenPort }}/?tls-chain=/certs/tls.crt&tls-key=/certs/tls.key
+          {{- else }}
+          - --listen-uri=insecure-validator://0.0.0.0:{{ .Values.ledgerValidator.listenPort }}/
+          {{- end }}
+        ports:
+          - name: validator
+            containerPort: {{ .Values.ledgerValidator.listenPort }}
+            protocol: TCP
+        volumeMounts:
+        - name: data
+          mountPath: /data
+        {{- if eq .Values.mirrorServiceTLS true }}
+        - name: tls-cert
+          mountPath: /certs
+          readOnly: true
+        {{- end }}
+        resources:
+          {{- toYaml .Values.ledgerValidator.resources | nindent 12 }}
+      nodeSelector:
+        {{- toYaml .Values.ledgerValidator.nodeSelector | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.ledgerValidator.affinity | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.ledgerValidator.tolerations | nindent 8 }}
+      volumes:
+      {{- if eq .Values.ledgerValidator.persistence.enabled false }}
+        - name: data
+          emptyDir: {}
+      {{- end }}
+      {{- if eq .Values.mirrorServiceTLS true }}
+        - name: tls-cert
+          secret:
+            secretName: {{ include "chart.fullname" .}}-lvn-cert-tls
+      {{- end }}
+  {{- if .Values.ledgerValidator.persistence.enabled }}
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      {{- toYaml .Values.ledgerValidator.persistence.spec | nindent 6 }}
+  {{- end }}
+{{- end }}

--- a/chart/templates/mirror-private-deployment.yaml
+++ b/chart/templates/mirror-private-deployment.yaml
@@ -28,7 +28,7 @@ spec:
         runAsGroup: 1000
       containers:
       - name: mirror-service-private
-        image: "{{ .Values.mirrorPrivate.image.repository }}:{{ .Values.mirrorPrivate.image.tag }}"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.mirrorPrivate.imagePullPolicy }}
         args:
           - /usr/local/bin/wallet-service-mirror-private

--- a/chart/templates/mirror-public-certificate.yaml
+++ b/chart/templates/mirror-public-certificate.yaml
@@ -5,8 +5,8 @@ metadata:
   name: {{ include "chart.fullname" . }}-public-cert
 spec:
   dnsNames:
-    - full-service-mirror-public
-    - full-service-mirror-public.{{ .Release.Namespace }}.svc.cluster.local
+    - {{ include "chart.fullname" . }}-public
+    - {{ include "chart.fullname" . }}-public.{{ .Release.Namespace }}.svc.cluster.local
   secretName: {{ include "chart.fullname" . }}-public-cert-tls
   issuerRef:
     name: internal-ca-issuer

--- a/chart/templates/mirror-public-deployment.yaml
+++ b/chart/templates/mirror-public-deployment.yaml
@@ -28,7 +28,7 @@ spec:
         runAsGroup: 1000
       containers:
       - name: mirror-service-public
-        image: "{{ .Values.mirrorPublic.image.repository }}:{{ .Values.mirrorPublic.image.tag }}"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.mirrorPublic.imagePullPolicy }}
         args:
           - /usr/local/bin/wallet-service-mirror-public
@@ -46,13 +46,13 @@ spec:
           readOnlyRootFilesystem: true
         ports:
           - name: http
-            containerPort: 9091
+            containerPort: {{ .Values.mirrorPublic.httpPort }}
             protocol: TCP
           - name: grpc
-            containerPort: 10080
+            containerPort: {{ .Values.mirrorPublic.grpcPort }}
             protocol: TCP
           - name: grpc-tls
-            containerPort: 10443
+            containerPort: {{ .Values.mirrorPublic.grpcTlsPort }}
             protocol: TCP
         {{- if eq .Values.mirrorServiceTLS true }}
         volumeMounts:

--- a/chart/templates/mirror-public-service.yaml
+++ b/chart/templates/mirror-public-service.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.mirrorPublic.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -10,17 +9,16 @@ spec:
   type: ClusterIP
   publishNotReadyAddresses: true
   ports:
-    - port: 9091
+    - port: {{ .Values.mirrorPublic.httpPort }}
       targetPort: http
       protocol: TCP
       name: http
-    - port: 10080
+    - port: {{ .Values.mirrorPublic.grpcPort }}
       targetPort: grpc
       name: grpc
-    - port: 10443
+    - port: {{ .Values.mirrorPublic.grpcTlsPort }}
       targetPort: grpc-tls
       name: grpc-tls
   selector:
     {{- include "chart.selectorLabels" . | nindent 4 }}
     app: mirror-service-public
-{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -8,22 +8,68 @@ imagePullSecrets:
 # Use Self Signed Cert for TLS between private and public service GRPC
 mirrorServiceTLS: false
 
-fullService:
+image:
+  repository: mobilecoin/full-service-mirror
+  tag: ''
+
+ledgerValidator:
   enabled: true
   replicaCount: 1
-  image:
-    repository: mobilecoin/full-service
-    tag: ''
+  listenPort: 5554
   imagePullPolicy: Always
   podAnnotations:
     fluentbit.io/include: 'true'
   args: []
   # Example args for testnet
+  # - /usr/local/bin/mc-validator-service
+  # - --ledger-db=/data/ledger.db
   # - --peer=mc://node1.test.mobilecoin.com/
   # - --peer=mc://node2.test.mobilecoin.com/
   # - --tx-source-url=https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node1.test.mobilecoin.com/
   # - --tx-source-url=https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node2.test.mobilecoin.com/
-  resources: {}
+
+  # Example args for mainnet
+  # - /usr/local/bin/mc-validator-service
+  # - --ledger-db=/data/ledger.db
+  # - --peer=mc://node1.prod.mobilecoinww.com/
+  # - --peer=mc://node2.prod.mobilecoinww.com/
+  # - --tx-source-url=https://ledger.mobilecoinww.com/node1.prod.mobilecoinww.com/
+  # - --tx-source-url=https://ledger.mobilecoinww.com/node2.prod.mobilecoinww.com/
+
+  nodeSelector: {}
+  tolerations: []
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: app
+                operator: In
+                values:
+                  - full-service
+          topologyKey: 'kubernetes.io/hostname'
+  persistence:
+    enabled: true
+    spec:
+      storageClassName: fast
+      accessModes:
+        - 'ReadWriteOnce'
+      resources:
+        requests:
+          storage: 128Gi
+
+fullService:
+  enabled: true
+  replicaCount: 1
+  listenPort: 9090
+  imagePullPolicy: Always
+  podAnnotations:
+    fluentbit.io/include: 'true'
+  args: []
+  # Example args for full-service
+  # - /usr/local/bin/full-service
+  # - --wallet-db=/data/wallet.db
+  # - --ledger-db=/data/ledger.db
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -38,11 +84,7 @@ fullService:
           storage: 128Gi
 
 mirrorPrivate:
-  enabled: true
   replicaCount: 1
-  image:
-    repository: mobilecoin/full-service-mirror
-    tag: ''
   imagePullPolicy: Always
   podAnnotations:
     fluentbit.io/include: 'true'
@@ -52,11 +94,10 @@ mirrorPrivate:
   affinity: {}
 
 mirrorPublic:
-  enabled: true
   replicaCount: 1
-  image:
-    repository: mobilecoin/full-service-mirror
-    tag: ''
+  httpPort: 9091
+  grpcPort: 10080
+  grpcTlsPort: 10443
   imagePullPolicy: Always
   podAnnotations:
     fluentbit.io/include: 'true'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,19 +1,41 @@
-version: "3.8"
+version: '3.8'
 
 services:
+  validator_service:
+    build:
+      context: ./
+      dockerfile: ./Dockerfile
+    volumes:
+      - validator-service:/data
+    tty: true
+    command:
+      - /usr/local/bin/mc-validator-service
+      - --ledger-db=/data/ledger.db
+      - --peer=mc://node1.test.mobilecoin.com/
+      - --peer=mc://node2.test.mobilecoin.com/
+      - --tx-source-url=https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node1.test.mobilecoin.com/
+      - --tx-source-url=https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node2.test.mobilecoin.com/
+      - --listen-uri=insecure-validator://0.0.0.0:5554/
+    expose:
+      - 5554
+    restart: always
 
   full_service:
     build:
-      context: ./full-service
+      context: ./
       dockerfile: ./Dockerfile
     volumes:
       - full-service:/data
     tty: true
     command:
-      - --peer=mc://node1.test.mobilecoin.com/
-      - --peer=mc://node2.test.mobilecoin.com/
-      - --tx-source-url=https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node1.test.mobilecoin.com/
-      - --tx-source-url=https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node2.test.mobilecoin.com/
+      - /usr/local/bin/full-service
+      - --listen-host=0.0.0.0
+      - --ledger-db=/data/ledger.db
+      - --wallet-db=/data/wallet.db
+      - --validator=insecure-validator://validator_service:5554/
+      - --fog-ingest-enclave-css=/usr/local/bin/ingest-enclave.css
+    depends_on:
+      - validator_service
     expose:
       - 9090
     restart: always
@@ -23,11 +45,12 @@ services:
       context: ./
       dockerfile: ./Dockerfile
     command:
-      - /usr/local/bin/wallet-service-mirror-private 
-      - --mirror-public-uri=insecure-wallet-service-mirror://wallet_service_mirror_public/ 
-      - --wallet-service-uri=http://full_service:9090/wallet 
+      - /usr/local/bin/wallet-service-mirror-private
+      - --mirror-public-uri=insecure-wallet-service-mirror://wallet_service_mirror_public/
+      - --wallet-service-uri=http://full_service:9090/wallet
     depends_on:
       - full_service
+      - wallet_service_mirror_public
     restart: always
 
   wallet_service_mirror_public:
@@ -35,14 +58,15 @@ services:
       context: ./
       dockerfile: ./Dockerfile
     command:
-      - /usr/local/bin/wallet-service-mirror-public 
+      - /usr/local/bin/wallet-service-mirror-public
       - --client-listen-uri=http://0.0.0.0:9091/
       - --mirror-listen-uri=insecure-wallet-service-mirror://0.0.0.0/
     ports:
-      - "9091:9091"
+      - '9091:9091'
     depends_on:
       - full_service
     restart: always
 
 volumes:
   full-service:
+  validator-service:


### PR DESCRIPTION
## Motivation
Update the helm chart to include the mc-validator-service and automate the deployments of the services to our Kubernetes Development cluster via Github Actions
 

## Included in this PR
- Update Helm chart to include `mc-validator-service` and refactor some values to make it more flexible
- Add deploy Github Action 
    - Leverage MC self hosted runners to decrese build times. ~22 minutes faster for this repo build
    - Deploy to staging environment for both mainnet and testnet for prerelease build
    - Deploy to prod environemnt for both mainnet and testnet for release build
- Update Dockerfile to include mc-validator-service
- Update Docker compose to incorporate mc-validator-service