### PR TITLE
Make .mobconf and rust-toolchain reference submodule

### DIFF
--- a/.mobconf
+++ b/.mobconf
@@ -1,4 +1,4 @@
 [image]
 target = builder-install
 repository = gcr.io/mobilenode-211420/
-Dockerfile-version = 1_12
+dockerfile = full-service/mobilecoin/docker/Dockerfile

--- a/mob
+++ b/mob
@@ -1,1 +1,1 @@
-mobilecoin/mob
+full-service/mob

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly-2021-07-21
+full-service/rust-toolchain


### PR DESCRIPTION
This makes `full-service-mirror` follow whatever versions are in the `full-service` submodule, which in turn references its `mobilecoin` submodule with https://github.com/mobilecoinofficial/full-service/pull/318

This leads to fewer references to update when upgrading the `rust-toolchain` or `builder-install` image. Updates can then be propagated when updating the submodule.